### PR TITLE
add alternate file-types "dtso" and "its"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
       "file-types": [
         "dts",
         "dtsi",
+        "dtso",
+        "its",
         "overlay"
       ],
       "injection-regex": "^(dts|devicetree)$"


### PR DESCRIPTION
The suffix "dtso" is an alternate name for devicetree overlays.

The suffix "its" is for U-Boot Flattened Image Trees which use the devicetree format.

See https://github.com/u-boot/u-boot/blob/master/doc/usage/fit/source_file_format.rst#terminology